### PR TITLE
Обновление функции: Обновлён поиск семейства по имени

### DIFF
--- a/ОВиВК.tab/Сортировка.panel/Обновление функции.pushbutton/script.py
+++ b/ОВиВК.tab/Сортировка.panel/Обновление функции.pushbutton/script.py
@@ -102,7 +102,7 @@ def copyEF(collection):
 
                 if element not in colGeneric:
                     setIfNotRO(parameter, EF)
-                if element in colGeneric:
+                if element in colGeneric and hasattr(element, "Symbol"):
                     if "_Якорный" not in element.Symbol.FamilyName:
                         setIfNotRO(parameter, EF)
 


### PR DESCRIPTION
Системное семейство текст модели тоже принадлежит категории "Обобщенные модели". Воизбежание, проверяем на наличие Symbol, при поиске якорных элементов