### PR TITLE
Обновление имени системы: Принудительное имя

### DIFF
--- a/ОВиВК.tab/Сортировка.panel/Обновление имени системы.pushbutton/script.py
+++ b/ОВиВК.tab/Сортировка.panel/Обновление имени системы.pushbutton/script.py
@@ -162,7 +162,9 @@ def rename_sub_sub(element, system_name):
 
 
 def check_forced_name(element):
-
+	if (element.Category.IsId(BuiltInCategory.OST_PipeInsulations)
+			or element.Category.IsId(BuiltInCategory.OST_DuctInsulations)):
+		element = document.GetElement(element.HostElementId)
 	forced_name = lookupCheck(element, 'ФОП_ВИС_Имя системы принудительное', isExit = False)
 
 	if not forced_name:


### PR DESCRIPTION
Принудительное имя системы должно ложиться на материалы изоляции от материнского элемента-хоста