### PR TITLE
Обновление имени системы: ReadOnly параметр ФОП_ВИС_Имя системы

### DIFF
--- a/ОВиВК.tab/Сортировка.panel/Обновление имени системы.pushbutton/script.py
+++ b/ОВиВК.tab/Сортировка.panel/Обновление имени системы.pushbutton/script.py
@@ -221,7 +221,11 @@ def update_system_name(element):
 			system_name = type_system_name
 
 	element.SetParamValue(SharedParamsConfig.Instance.MechanicalSystemName, str(system_name))
-	element.LookupParameter('ФОП_ВИС_Имя системы').Set(str(system_name))
+
+	sharedVisName = element.GetSharedParam(SharedParamsConfig.Instance.VISSystemName.Name)
+
+	if not sharedVisName.IsReadOnly:
+		sharedVisName.Set(str(system_name))
 
 
 def update_element(elements):


### PR DESCRIPTION
Был пропущен кусок на проверку ридонли имени системы - теперь если параметр заблокирован в ревите, идем дальше.