### PR TITLE
Расчет расходников: Исправлены баги, скорректированы расчеты

### DIFF
--- a/lib/unmodeling_class_library.py
+++ b/lib/unmodeling_class_library.py
@@ -713,7 +713,6 @@ class MaterialCalculator:
         else:
             area = element.GetParamValueOrDefault(BuiltInParameter.RBS_CURVE_SURFACE_AREA)
 
-        # Такая ситуация возможна только
         if element.Category.IsId(BuiltInCategory.OST_DuctInsulations):
             host = self.doc.GetElement(element.HostElementId)
             if host.Category.IsId(BuiltInCategory.OST_DuctFitting):

--- a/lib/unmodeling_class_library.py
+++ b/lib/unmodeling_class_library.py
@@ -674,7 +674,7 @@ class MaterialCalculator:
             for face in solid.Faces:
                 area += face.Area
 
-        # Складываем площадь коннекторов хоста с учетом толщины изоляции
+        # Складываем площадь коннекторов хоста
         if area > 0:
             false_area = 0
             connectors = self.get_connectors(host)

--- a/lib/unmodeling_class_library.py
+++ b/lib/unmodeling_class_library.py
@@ -650,6 +650,50 @@ class MaterialCalculator:
     """
     Класс-калькулятор для расходных элементов труб и воздуховодов.
     """
+    doc = None
+
+    def __init__(self, doc):
+        self.doc = doc
+
+    def get_connectors(self, element):
+        connectors = []
+
+        if isinstance(element, FamilyInstance) and element.MEPModel.ConnectorManager is not None:
+            connectors.extend(element.MEPModel.ConnectorManager.Connectors)
+
+        if element.InAnyCategory([BuiltInCategory.OST_DuctCurves, BuiltInCategory.OST_PipeCurves]) and \
+                isinstance(element, MEPCurve) and element.ConnectorManager is not None:
+            connectors.extend(element.ConnectorManager.Connectors)
+
+        return connectors
+
+    def get_fitting_insulation_area(self, element, host):
+        area = 0
+
+        for solid in dosymep.Revit.Geometry.ElementExtensions.GetSolids(host):
+            for face in solid.Faces:
+                area += face.Area
+
+        # Складываем площадь коннекторов хоста с учетом толщины изоляции
+        if area > 0:
+            false_area = 0
+            connectors = self.get_connectors(host)
+            for connector in connectors:
+                if connector.Shape == ConnectorProfileType.Rectangular:
+                    height = connector.Height
+                    width = connector.Width
+
+                    false_area += height * width
+                if connector.Shape == ConnectorProfileType.Round:
+                    radius = connector.Radius
+                    false_area += radius * radius * math.pi
+                if connector.Shape == ConnectorProfileType.Oval:
+                    false_area += 0
+
+            # Вычитаем площадь пустоты на местах коннекторов
+            area -= false_area
+
+        return area
 
     def get_curve_len_area_parameters_values(self, element):
         """
@@ -669,8 +713,20 @@ class MaterialCalculator:
         else:
             area = element.GetParamValueOrDefault(BuiltInParameter.RBS_CURVE_SURFACE_AREA)
 
-        if length is None or area is None:
-            return 0, 0
+        # Такая ситуация возможна только
+        if element.Category.IsId(BuiltInCategory.OST_DuctInsulations):
+            host = self.doc.GetElement(element.HostElementId)
+            if host.Category.IsId(BuiltInCategory.OST_DuctFitting):
+                # Для залагавшей изоляции
+                if host is None:
+                    return 0, 0
+
+                area = self.get_fitting_insulation_area(element, host)
+
+        if length is None:
+            length = 0
+        if area is None:
+            area = 0
 
         length = UnitUtils.ConvertFromInternalUnits(length, UnitTypeId.Meters)
         area = UnitUtils.ConvertFromInternalUnits(area, UnitTypeId.SquareMeters)

--- a/ОВиВК.tab/Спецификации.panel/Дополнительные.stack/Немоделируемые.pulldown/Импорт немоделируемых.pushbutton/script.py
+++ b/ОВиВК.tab/Спецификации.panel/Дополнительные.stack/Немоделируемые.pulldown/Импорт немоделируемых.pushbutton/script.py
@@ -127,7 +127,7 @@ def script_execute(plugin_logger):
                 "Ошибка",
                 exitscript=True)
 
-        if type(mass) is not str:
+        if type(mass) is not str and mass is not None:
             error = "Значение массы в строке '{}' не является текстом.".format(row)
             forms.alert(
                 error,

--- a/ОВиВК.tab/Спецификации.panel/Дополнительные.stack/Немоделируемые.pulldown/Расчет расходников.pushbutton/script.py
+++ b/ОВиВК.tab/Спецификации.panel/Дополнительные.stack/Немоделируемые.pulldown/Расчет расходников.pushbutton/script.py
@@ -24,7 +24,7 @@ from dosymep_libs.bim4everyone import *
 
 doc = __revit__.ActiveUIDocument.Document
 view = doc.ActiveView
-material_calculator = MaterialCalculator()
+material_calculator = MaterialCalculator(doc)
 unmodeling_factory = UnmodelingFactory()
 
 def get_material_hosts(element_types, calculation_name, builtin_category):
@@ -268,11 +268,21 @@ def process_insulation_consumables(family_symbol, consumable_description):
 
                     for element in elements:
                         length, area = material_calculator.get_curve_len_area_parameters_values(element)
+
+                        if element.Category.IsId(BuiltInCategory.OST_PipeInsulations):
+                            stock = (doc.ProjectInformation
+                                     .GetParamValueOrDefault(SharedParamsConfig.Instance.VISPipeInsulationReserve))/100
+                        else:
+                            stock = (doc.ProjectInformation
+                                     .GetParamValueOrDefault(SharedParamsConfig.Instance.VISDuctInsulationReserve))/100
+
                         if (consumable.is_expenditure_by_linear_meter == 0
                                 or consumable.is_expenditure_by_linear_meter is None):
-                            new_consumable_row.number += consumable.expenditure * area
+                            value = consumable.expenditure * area + consumable.expenditure * area * stock
+                            new_consumable_row.number += value
                         else:
-                            new_consumable_row.number += consumable.expenditure * length
+                            value = consumable.expenditure * length + consumable.expenditure * length * stock
+                            new_consumable_row.number += value
 
                     consumable_location = unmodeling_factory.update_location(consumable_location)
 


### PR DESCRIPTION
1) Добавлен учет запаса изоляции воздуховодов-трубопроводов на ее расходниках
2) Исправлена ошибка, при None в ячейке массы не давало загрузить таблицу
3) Добавлен расчет расходников для изоляции фитингов воздуховодов