### PR TITLE
Нумерация и примечания: Смешанные модели АИ

### DIFF
--- a/lib/numerate_class_library.py
+++ b/lib/numerate_class_library.py
@@ -156,6 +156,24 @@ class SpecificationFiller:
     duct_stock = 0  # Запас изоляции из сведений о проекте
     types_cash = {}  # Кэш данных по индивидуальным запасов из типов воздуховодов-фитингов
 
+    mechanical_categories = [
+        BuiltInCategory.OST_DuctFitting,
+        BuiltInCategory.OST_PipeFitting,
+        BuiltInCategory.OST_PipeCurves,
+        BuiltInCategory.OST_DuctCurves,
+        BuiltInCategory.OST_FlexDuctCurves,
+        BuiltInCategory.OST_FlexPipeCurves,
+        BuiltInCategory.OST_DuctTerminal,
+        BuiltInCategory.OST_DuctAccessory,
+        BuiltInCategory.OST_PipeAccessory,
+        BuiltInCategory.OST_MechanicalEquipment,
+        BuiltInCategory.OST_DuctInsulations,
+        BuiltInCategory.OST_PipeInsulations,
+        BuiltInCategory.OST_PlumbingFixtures,
+        BuiltInCategory.OST_Sprinklers,
+        BuiltInCategory.OST_CableTray
+    ]
+
     def __init__(self, doc, active_view):
         """
         Инициализация экземпляра класса SpecificationFiller.
@@ -389,6 +407,9 @@ class SpecificationFiller:
             shared_param: RevitParam с платформы
             value: Устанавливаемое значение
         """
+        if not element.IsExistsParam(shared_param):
+            return
+
         param = element.GetParam(shared_param)
         if not param.IsReadOnly:
             element.SetParamValue(shared_param, value)
@@ -450,7 +471,12 @@ class SpecificationFiller:
         Returns:
             Имя параметра или None если все в норме
         """
+
+
         for element in elements:
+            if not element.InAnyCategory(self.mechanical_categories):
+                continue
+
             if not element.IsExistsSharedParam(revit_param.Name):
                 return revit_param.Name
         return None
@@ -469,7 +495,7 @@ class SpecificationFiller:
 
         if results:
             forms.alert(
-                'Параметры {} найдены не у всех экземпляров воздуховодов/труб.'.format(', '.join(results)),
+                'Параметры {} найдены не у всех элементов спецификации.'.format(', '.join(results)),
                 "Внимание")
 
     def __setup_params(self):

--- a/lib/numerate_class_library.py
+++ b/lib/numerate_class_library.py
@@ -471,8 +471,6 @@ class SpecificationFiller:
         Returns:
             Имя параметра или None если все в норме
         """
-
-
         for element in elements:
             if not element.InAnyCategory(self.mechanical_categories):
                 continue


### PR DESCRIPTION
Фикс необычного бага на моделях АИ. В спецификацию ВИС в невидимом виде попадают элементы типа графических стилей, ограждений и прочих вещей которые оттуда отфильтрованы в ревите. По какой-то причине их можно получить при переборе строк, хотя визуально их найти не получается и в элементах активного вида их не существует, что приводит к крашу при попытке заполнения параметра позиции. 

На обычных моделях эта ошибка не возникает, т.к. не существует элементов кроме ВИС.

Фильтруем элементы по категории и не пытаемся заполнить параметр, если его все же нет(просто выдаем предупреждение).