### PR TITLE
Немоделируемые: Смена алгоритма расчета диаметра хомутов, хомута рапид

### DIFF
--- a/ОВиВК.tab/Спецификации.panel/Дополнительные.stack/lib/unmodeling_class_library.py
+++ b/ОВиВК.tab/Спецификации.panel/Дополнительные.stack/lib/unmodeling_class_library.py
@@ -1027,8 +1027,9 @@ class MaterialCalculator:
 
         if pipe_diameter not in d_variants:
             return 0
+        collars_count = int(math.ceil(pipe_length / 3.0)) - 1
 
-        return int(pipe_length/3) - 1
+        return collars_count
 
     def get_collars_and_pins_number(self, pipe, pipe_diameter, pipe_length):
         """

--- a/ОВиВК.tab/Спецификации.panel/Дополнительные.stack/lib/unmodeling_class_library.py
+++ b/ОВиВК.tab/Спецификации.panel/Дополнительные.stack/lib/unmodeling_class_library.py
@@ -249,6 +249,7 @@ class UnmodelingFactory:
     COLOR_RULE_NAME = 'Краска антикоррозионная, покрытие в два слоя. Расход - 0.2 кг на м²'
     GRUNT_RULE_NAME = 'Грунтовка для стальных труб, покрытие в один слой. Расход - 0.1 кг на м²'
     CLAMPS_RULE_NAME = 'Хомут трубный под шпильку М8'
+    RAPID_CLAMPS_RULE_NAME = 'Хомут соединительный Rapid'
     PIN_RULE_NAME = 'Шпилька М8 1м/1шт'
 
     FAMILY_NAME = '_Якорный элемент'
@@ -364,7 +365,7 @@ class UnmodelingFactory:
             group=rule_set.group,
             name=rule_set.name,
             mark=rule_set.mark,
-            code=rule_set.code,
+            code = rule_set.code,
             maker=rule_set.maker,
             unit=rule_set.unit,
             local_description=material_description,
@@ -499,6 +500,15 @@ class UnmodelingFactory:
                 unit="шт.",
                 maker="",
                 method_name=SharedParamsConfig.Instance.VISIsClampsCalculation.Name,
+                category=BuiltInCategory.OST_PipeCurves),
+            GenerationRuleSet(
+                group=self.MATERIAL_GROUP,
+                name=self.RAPID_CLAMPS_RULE_NAME,
+                mark="",
+                code="",
+                unit="шт.",
+                maker="",
+                method_name="ФОП_ВИС_Расчет хомутов Rapid",
                 category=BuiltInCategory.OST_PipeCurves)
         ]
         return gen_list
@@ -1000,6 +1010,25 @@ class MaterialCalculator:
         if number < 1:
             number = 1
         return int(number)
+
+    def get_rapid_collars_number(self, pipe_diameter, pipe_length):
+        """Возвращает число хомутов Rapid на трубу. Если размер трубы не подходит - возвращает 0 и хомут не создается
+        Args:
+            pipe_diameter: Диаметр трубы.
+            pipe_length: Длина трубы.
+
+        Returns:
+            int: Количество хомутов.
+        """
+        if pipe_length <= 3:
+            return 0
+
+        d_variants = [50, 70, 80, 100, 125, 150, 200]
+
+        if pipe_diameter not in d_variants:
+            return 0
+
+        return int(pipe_length/3) - 1
 
     def get_collars_and_pins_number(self, pipe, pipe_diameter, pipe_length):
         """

--- a/ОВиВК.tab/Спецификации.panel/Дополнительные.stack/Немоделируемые.pulldown/Расчет расходников.pushbutton/script.py
+++ b/ОВиВК.tab/Спецификации.panel/Дополнительные.stack/Немоделируемые.pulldown/Расчет расходников.pushbutton/script.py
@@ -194,15 +194,6 @@ def process_materials(family_symbol, material_description):
             full_diameter = UnitUtils.ConvertFromInternalUnits(
                 pipe.GetParamValue(BuiltInParameter.RBS_PIPE_OUTER_DIAMETER),
                 UnitTypeId.Millimeters)
-            pipe_insulation_filter = ElementCategoryFilter(BuiltInCategory.OST_PipeInsulations)
-            dependent_elements = pipe.GetDependentElements(pipe_insulation_filter)
-
-            if len(dependent_elements) > 0:
-                insulation = doc.GetElement(dependent_elements[0])
-                insulation_thikness = UnitUtils.ConvertFromInternalUnits(
-                    insulation.Thickness,
-                    UnitTypeId.Millimeters)
-                full_diameter += insulation_thikness
 
             if full_diameter not in pipe_dict:
                 pipe_dict[full_diameter] = []

--- a/ОВиВК.tab/Спецификации.panel/Дополнительные.stack/Немоделируемые.pulldown/Расчет расходников.pushbutton/script.py
+++ b/ОВиВК.tab/Спецификации.panel/Дополнительные.stack/Немоделируемые.pulldown/Расчет расходников.pushbutton/script.py
@@ -200,7 +200,7 @@ def process_materials(family_symbol, material_description):
                 UnitTypeId.Millimeters)
 
             pipe_nominal_diameter = UnitUtils.ConvertFromInternalUnits(
-                pipe.GetParamValue(BuiltInParameter.RBS_CALCULATED_SIZE),
+                pipe.GetParamValue(BuiltInParameter.RBS_PIPE_INNER_DIAM_PARAM),
                 UnitTypeId.Millimeters)
 
             key = (full_diameter, pipe_nominal_diameter)


### PR DESCRIPTION
По замечаниям инженеров толщина изоляции была убрана из расчета диаметра хомутов, сначала монтируется хомут и потом уже изолируется труба с ним.

Добавлен обсчет хомутов Rapid для SML-труб. 