### PR TITLE
Смена уровней: Ошибка при закрытии окна

### DIFF
--- a/ОВиВК.tab/Параметры и элементы.panel/Смена уровней.pushbutton/script.py
+++ b/ОВиВК.tab/Параметры и элементы.panel/Смена уровней.pushbutton/script.py
@@ -188,9 +188,8 @@ def get_selected_mode():
                                "Все элементы на активном виде к выбранному уровню",
                                "Выбранные элементы к выбранному уровню"])
 
-    if method is None:
-        forms.alert("Метод не выбран", "Ошибка", exitscript=True)
-    return method
+    if method is False:
+        sys.exit()
 
 def get_selected_level(method):
     """ Возвращаем выбранный уровень или False, если режим работы не подразумевает такого """

--- a/ОВиВК.tab/Параметры и элементы.panel/Смена уровней.pushbutton/script.py
+++ b/ОВиВК.tab/Параметры и элементы.panel/Смена уровней.pushbutton/script.py
@@ -189,7 +189,7 @@ def get_selected_mode():
                                "Выбранные элементы к выбранному уровню"])
 
     if method is False:
-        sys.exit()
+        script.exit()
 
 def get_selected_level(method):
     """ Возвращаем выбранный уровень или False, если режим работы не подразумевает такого """


### PR DESCRIPTION
Новое окно вывода возвращает False, а не None, что приводило к ошибкам при закрытии окна