### PR TITLE
Расчет аэродинамики: Получение коннекторов из присоединенной арматуры

### DIFF
--- a/ОВиВК.tab/Расчеты.panel/Расчет аэродинамики.pushbutton/lib/CalculatorClassLib.py
+++ b/ОВиВК.tab/Расчеты.panel/Расчет аэродинамики.pushbutton/lib/CalculatorClassLib.py
@@ -83,7 +83,8 @@ class ConnectorData:
         for reference in self.connector_element.AllRefs:
             if reference.Owner.InAnyCategory([BuiltInCategory.OST_DuctCurves,
                                               BuiltInCategory.OST_DuctFitting,
-                                              BuiltInCategory.OST_MechanicalEquipment]):
+                                              BuiltInCategory.OST_MechanicalEquipment,
+                                              BuiltInCategory.OST_DuctAccessory]):
                 self.connected_element = reference.Owner
 
 class MulticonElementCharacteristic:


### PR DESCRIPTION
В редких случаях выполняется подключение арматуры напрямую во врезки, что приводило к ошибкам.