### PR TITLE
Отметки уровня: Расширение функционала

### DIFF
--- a/ОВиВК.tab/Виды.panel/Отметки уровней.pushbutton/script.py
+++ b/ОВиВК.tab/Виды.panel/Отметки уровней.pushbutton/script.py
@@ -291,17 +291,20 @@ def get_type_annotation():
         .WhereElementIsNotElementType() \
         .ToElements()
 
-    target_family_name = "ТипАн_Мрк_B4E_Уровень"
-    target_floor_name = "ТипАн_Мрк_B4E_Перекрытие"
+    target_level_mark_name = "ТипАн_Мрк_B4E_Уровень"
+    target_floor_mark_name = "ТипАн_Мрк_B4E_Перекрытие"
 
-    filtered_annotations = [el for el in generic_annotations if el.Symbol.Family.Name == target_family_name]
-    if len(filtered_annotations) == 0:
+    level_annotations = [el for el in generic_annotations if el.Symbol.Family.Name == target_level_mark_name]
+    if len(level_annotations) == 0:
         forms.alert("Разместите на виде хотя бы одно шаблонное семейство {}."
-                    .format(target_family_name),
+                    .format(target_level_mark_name),
                     "Ошибка",
                     exitscript=True)
 
-    return filtered_annotations[0]
+    floor_annotations = [el for el in generic_annotations if el.Symbol.Family.Name == target_floor_mark_name]
+    floor_annotation = floor_annotations[0] if len(floor_annotations) != 0 else None
+
+    return {"level_mark": level_annotations[0], "floor_mark": floor_annotation}
 
 
 def get_first_leader_point(type_annotation):
@@ -324,9 +327,14 @@ def get_type_annotation_origin(type_annotation):
 @log_plugin(EXEC_PARAMS.command_name)
 def script_execute(plugin_logger):
     start_up_checks()
-    type_annotation = get_type_annotation()
-    type_annotation_id = type_annotation.Id
-    orig_pont = get_type_annotation_origin(type_annotation)
+    type_annotation_dict = get_type_annotation()
+    level_annotation = type_annotation_dict["level_mark"]
+    level_annotation_id = level_annotation.Id
+    level_orig_pont = get_type_annotation_origin(level_annotation)
+
+    floor_annotation = type_annotation_dict["floor_mark"]
+    floor_annotation_id = floor_annotation.Id if floor_annotation is not None else None
+    floor_orig_pont = get_type_annotation_origin(floor_annotation) if floor_annotation is not None else None
 
     elements = get_pre_selected() or get_selected()
 
@@ -348,13 +356,16 @@ def script_execute(plugin_logger):
                     continue
 
                 new_point = XYZ(connector_coord_1.X, connector_coord_1.Y, level.elevation + z_correction)
-                translation = new_point - orig_pont
-                new_tag_id = ElementTransformUtils.CopyElement(doc, type_annotation_id, translation)
+                translation = new_point - level_orig_pont
+                new_tag_id = ElementTransformUtils.CopyElement(doc, level_annotation_id, translation)
                 new_tag = doc.GetElement(new_tag_id[0])
                 new_tag.SetParamValue("Имя уровня", level.name)
                 elevation = UnitUtils.ConvertFromInternalUnits(level.elevation,
                                                    UnitTypeId.Meters)
                 string_elevation = "{:+.3f}".format(elevation)
+                if floor_annotation_id is not None:
+                    floor_translation = new_point - floor_orig_pont
+                    ElementTransformUtils.CopyElement(doc, floor_annotation_id, floor_translation)
                 new_tag.SetParamValue("Отметка уровня", string_elevation)
 
 

--- a/ОВиВК.tab/Виды.panel/Отметки уровней.pushbutton/script.py
+++ b/ОВиВК.tab/Виды.panel/Отметки уровней.pushbutton/script.py
@@ -141,9 +141,7 @@ def get_connector_coordinates(element):
                 break
 
     if start_point is None and end_point is None:
-        forms.alert("Не удалось получить координаты коннекторов. ID: {}".format(str(element.Id)),
-                    "Ошибка",
-                    exitscript=True)
+        return None
 
     # Если у нас встречается элемент с одним коннектором - получает bbox и добавляем его высоту к стартовой точке
     if end_point is None:
@@ -294,6 +292,7 @@ def get_type_annotation():
         .ToElements()
 
     target_family_name = "ТипАн_Мрк_B4E_Уровень"
+    target_floor_name = "ТипАн_Мрк_B4E_Перекрытие"
 
     filtered_annotations = [el for el in generic_annotations if el.Symbol.Family.Name == target_family_name]
     if len(filtered_annotations) == 0:
@@ -305,13 +304,29 @@ def get_type_annotation():
     return filtered_annotations[0]
 
 
+def get_first_leader_point(type_annotation):
+    leaders = list(type_annotation.GetLeaders())
+    if len(leaders) != 0:
+        return leaders[0].End
+
+    return None
+
+
+def get_type_annotation_origin(type_annotation):
+    leader_point = get_first_leader_point(type_annotation)
+    if leader_point is not None:
+        return leader_point
+
+    return type_annotation.Location.Point
+
+
 @notification()
 @log_plugin(EXEC_PARAMS.command_name)
 def script_execute(plugin_logger):
     start_up_checks()
     type_annotation = get_type_annotation()
     type_annotation_id = type_annotation.Id
-    orig_pont = type_annotation.Location.Point
+    orig_pont = get_type_annotation_origin(type_annotation)
 
     elements = get_pre_selected() or get_selected()
 
@@ -320,6 +335,8 @@ def script_execute(plugin_logger):
 
     for element in elements:
         coord_list = get_connector_coordinates(element)
+        if coord_list is None:
+            continue
         connector_coord_1 = coord_list[0]
         connector_coord_2 = coord_list[1]
         min_z = min(connector_coord_1.Z, connector_coord_2.Z) - z_correction


### PR DESCRIPTION
1) В семействах уровня добавлена возможность работы с стандартной выноской ревита. Скрипт обновлен, теперь базовая точка для вставки семейства при наличии выноски считается точкой окончания выноски. 

2) Инженеры дублируют размещение отметок отрисовкой перекрытий для графического отображения уровней. Добавлена обработка еще одной типовой аннотации, при наличии целевом виде - копируется вместе с основной

<img width="487" height="216" alt="image" src="https://github.com/user-attachments/assets/f772f239-65ef-4c30-af32-8bb7e7487006" />

3) На видах чаще чем ожидалось встречаются элементы без коннекторов вообще. Как правило - элементы оформления висящие не в той категории. Это не ошибка, их просто нужно игнорировать. Пропускаем их без падения. 

